### PR TITLE
ci: add zizmor GitHub Actions security analysis workflow

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8.4 |
-| <a name="requirement_cloudinit"></a> [cloudinit](#requirement\_cloudinit) | 2.3.7 |
-| <a name="requirement_http"></a> [http](#requirement\_http) | 3.4.4 |
 
 ## Example
 
@@ -31,30 +29,14 @@
 # This code is found in the examples directory.
 terraform {
   required_version = ">= 1.8.4"
-  required_providers {
-    hcloud = {
-      source  = "hetznercloud/hcloud"
-      version = "1.47.0"
-    }
-  }
 }
-
-provider "hcloud" {}
 
 module "coolify" {
   source = "../"
 }
 
-resource "hcloud_server" "coolify" {
-  name        = "coolify"
-  image       = "ubuntu-24.04"
-  server_type = "cax11"
-  location    = "nbg1"
-  public_net {
-    ipv4_enabled = true
-    ipv6_enabled = true
-  }
-  user_data = module.coolify.user_data
+output "user_data" {
+  value = module.coolify.user_data
 }
 ```
 
@@ -62,8 +44,8 @@ resource "hcloud_server" "coolify" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | 2.3.7 |
-| <a name="provider_http"></a> [http](#provider\_http) | 3.4.4 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | n/a |
+| <a name="provider_http"></a> [http](#provider\_http) | n/a |
 
 ## Modules
 
@@ -85,6 +67,6 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [cloudinit_config.coolify](https://registry.terraform.io/providers/hashicorp/cloudinit/2.3.7/docs/data-sources/config) | data source |
-| [http_http.install_script](https://registry.terraform.io/providers/hashicorp/http/3.4.4/docs/data-sources/http) | data source |
+| [cloudinit_config.coolify](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
+| [http_http.install_script](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
 <!-- END_TF_DOCS -->


### PR DESCRIPTION
Adds a pinned zizmor workflow to audit GitHub Actions security posture on pull requests and default-branch pushes.\n\nSecurity defaults included:\n- top-level permissions: {}\n- checkout with persist-credentials: false\n- pinned action SHAs for checkout + zizmor action\n\nThis helps prevent reintroducing risky workflow patterns (including unsafe pull_request_target usage).